### PR TITLE
Ensure correct TimeZone

### DIFF
--- a/upload_sop.sh
+++ b/upload_sop.sh
@@ -7,7 +7,7 @@ source "$(dirname "$0")/auth_and_prepare.sh"
 echo "✅ Pre-merge validation passed!"
 
 # Get the current date in the format MM/DD/YYYY
-current_date=$(date +"%m/%d/%Y")
+current_date=$(TZ="America/Chicago" date +"%m/%d/%Y")
 
 echo "✅ Current date: $current_date"
 


### PR DESCRIPTION
Fixes #13

For Qualer uploads, any sync occurring in the evening would produce mismatched dates, due to a discrepancy in time zones used for calculating the date.  This change ensures that the date will be set according to Central Time zone for Qualer uploads.